### PR TITLE
Fix minor data race

### DIFF
--- a/master.go
+++ b/master.go
@@ -188,7 +188,10 @@ func (e *etcdLock) acquire() (ret error) {
 	for {
 		// Stop was called, stop the refresh routine if needed and
 		// abort the acquire routine.
-		if !e.enabled {
+		e.Lock()
+		enabled := e.enabled
+		e.Unlock()
+		if !enabled {
 			if e.holding {
 				glog.V(2).Infof("Deleting lock %s", e.name)
 				// Delete the lock so other nodes can get it sooner.

--- a/master.go
+++ b/master.go
@@ -186,11 +186,11 @@ func (e *etcdLock) acquire() (ret error) {
 	err := fmt.Errorf("Dummy error")
 
 	for {
-		// Stop was called, stop the refresh routine if needed and
-		// abort the acquire routine.
 		e.Lock()
 		enabled := e.enabled
 		e.Unlock()
+		// Stop was called, stop the refresh routine if needed and
+		// abort the acquire routine.
 		if !enabled {
 			if e.holding {
 				glog.V(2).Infof("Deleting lock %s", e.name)


### PR DESCRIPTION
My tests reported a data race between https://github.com/datawisesystems/etcd-lock/blob/5781e990c2eb20031bab9d23aae98ca071d81e68/master.go#L142 and https://github.com/datawisesystems/etcd-lock/blob/5781e990c2eb20031bab9d23aae98ca071d81e68/master.go#L191

Second line is not protected by mutex.

This PR fixes it.
